### PR TITLE
Handle truncated packets in ofp_packet_in messages

### DIFF
--- a/src/of12/openflow-120.cpp
+++ b/src/of12/openflow-120.cpp
@@ -70,8 +70,8 @@ functions and methods. */
     this->mFM.addBoolean(tree, field, this->_tvb, this->_offset, length, bitmap)
 #define ADD_CHILD(tree, field, length) \
     this->mFM.addItem(tree, field, this->_tvb, this->_offset, length); this->_offset += length
-#define ADD_DISSECTOR(tree, field, length)	\
-    this->mFM.addDissector(tree, field, this->_tvb, this->_pinfo, this->_ether_handle, this->_offset, length); this->_offset += length
+#define ADD_DISSECTOR(tree, field, length, reported_length)                             \
+    this->mFM.addDissector(tree, field, this->_tvb, this->_pinfo, this->_ether_handle, this->_offset, length, reported_length); this->_offset += length
 #define CONSUME_BYTES(length) \
     this->_offset += length
 
@@ -434,6 +434,7 @@ void DissectorContext::dissect_ofp_packet_in() {
     ADD_TREE(tree, "ofp_packet_in");
 
     ADD_CHILD(tree, "ofp_packet_in.buffer_id", 4);
+    READ_UINT16(total_len);
     ADD_CHILD(tree, "ofp_packet_in.total_len", 2);
     ADD_CHILD(tree, "ofp_packet_in.reason", 1);
     ADD_CHILD(tree, "ofp_packet_in.table_id", 1);
@@ -444,7 +445,7 @@ void DissectorContext::dissect_ofp_packet_in() {
     ADD_CHILD(tree, "padding", 2);
 
     if (this->_oflen - this->_offset > 0) {
-	ADD_DISSECTOR(tree, "ofp_packet_in.data", this->_oflen - this->_offset);
+	ADD_DISSECTOR(tree, "ofp_packet_in.data", this->_oflen - this->_offset, total_len);
     } else
 	ADD_CHILD(tree, "ofp_packet_in.data", this->_oflen - this->_offset);
 }
@@ -464,7 +465,7 @@ void DissectorContext::dissect_ofp_packet_out() {
     }
 
     if (this->_oflen - this->_offset > 0) {
-	ADD_DISSECTOR(tree, "ofp_packet_out.data", this->_oflen - this->_offset);
+	ADD_DISSECTOR(tree, "ofp_packet_out.data", this->_oflen - this->_offset, this->_oflen - this->_offset);
     } else
 	ADD_CHILD(tree, "ofp_packet_out.data", this->_oflen - this->_offset);
 }

--- a/src/of13/openflow-130.cpp
+++ b/src/of13/openflow-130.cpp
@@ -73,8 +73,8 @@ functions and methods. */
     this->mFM.addBoolean(tree, field, this->_tvb, this->_offset, length, bitmap)
 #define ADD_CHILD(tree, field, length) \
     this->mFM.addItem(tree, field, this->_tvb, this->_offset, length); this->_offset += length
-#define ADD_DISSECTOR(tree, field, length)	\
-    this->mFM.addDissector(tree, field, this->_tvb, this->_pinfo, this->_ether_handle, this->_offset, length); this->_offset += length
+#define ADD_DISSECTOR(tree, field, length, reported_length)                             \
+    this->mFM.addDissector(tree, field, this->_tvb, this->_pinfo, this->_ether_handle, this->_offset, length, reported_length); this->_offset += length
 #define CONSUME_BYTES(length) \
     this->_offset += length
 
@@ -576,6 +576,7 @@ void DissectorContext::dissect_ofp_packet_in() {
     ADD_TREE(tree, "ofp_packet_in");
 
     ADD_CHILD(tree, "ofp_packet_in.buffer_id", 4);
+    READ_UINT16(total_len);
     ADD_CHILD(tree, "ofp_packet_in.total_len", 2);
     ADD_CHILD(tree, "ofp_packet_in.reason", 1);
     ADD_CHILD(tree, "ofp_packet_in.table_id", 1);
@@ -586,7 +587,7 @@ void DissectorContext::dissect_ofp_packet_in() {
     ADD_CHILD(tree, "padding", 2);
 
     if (this->_oflen - this->_offset > 0) {
-	ADD_DISSECTOR(tree, "ofp_packet_in.data", this->_oflen - this->_offset);
+	ADD_DISSECTOR(tree, "ofp_packet_in.data", this->_oflen - this->_offset, total_len);
     } else
 	ADD_CHILD(tree, "ofp_packet_in.data", this->_oflen - this->_offset);
 }
@@ -607,7 +608,7 @@ void DissectorContext::dissect_ofp_packet_out() {
 
     // TODO: should we check to see it it's really Ethernet?
     if (this->_oflen - this->_offset > 0) {
-	   ADD_DISSECTOR(tree, "ofp_packet_out.data", this->_oflen - this->_offset);
+	   ADD_DISSECTOR(tree, "ofp_packet_out.data", this->_oflen - this->_offset, this->_oflen - this->_offset);
     }
     else {
 	   ADD_CHILD(tree, "ofp_packet_out.data", this->_oflen - this->_offset);

--- a/src/util/FieldManager.cpp
+++ b/src/util/FieldManager.cpp
@@ -83,13 +83,13 @@ proto_item* FieldManager::addBoolean (proto_tree *tree, std::string key, tvbuff_
         std::cerr << "Couldn't find key: " << key << std::endl;
 }
 
-void FieldManager::addDissector (proto_tree *tree, std::string key, tvbuff_t *tvb, packet_info *pinfo, dissector_handle_t handle, guint32 start, guint32 len) {
+void FieldManager::addDissector (proto_tree *tree, std::string key, tvbuff_t *tvb, packet_info *pinfo, dissector_handle_t handle, guint32 start, guint32 len, guint32 reported_len) {
     // TODO: move this check to a function
     if (this->mFields.find(key) != this->mFields.end()) {
     	tvbuff_t *next_tvb;
 
     	/* Create the tvbuffer for the next dissector */
-        next_tvb = tvb_new_subset(tvb, start, len, len);
+        next_tvb = tvb_new_subset(tvb, start, len, reported_len);
     	/* call the next dissector */
     	call_dissector(handle, next_tvb, pinfo, tree);
     } else {

--- a/src/util/FieldManager.hpp
+++ b/src/util/FieldManager.hpp
@@ -97,8 +97,9 @@ class FieldManager {
     \param handle Dissector Handle
     \param start Starting byte position in the packet buffer for the data in this item
     \param len Length of the packet data covering this item
+    \param reported_len Length of the packet before truncation
     */
-    void addDissector(proto_tree* parent, std::string key, tvbuff_t *tvb, packet_info *pinfo, dissector_handle_t handle, guint32 start, guint32 len);
+    void addDissector(proto_tree* parent, std::string key, tvbuff_t *tvb, packet_info *pinfo, dissector_handle_t handle, guint32 start, guint32 len, guint32 reported_len);
 
     private:
     std::map<std::string, gint*>  mFields;


### PR DESCRIPTION
Use the total_len field in the ofp_packet_in message, so that Wireshark
attempts to extract as much information as possible from truncated
packages.
