### PR TITLE
Use dissector_add_uint instead of dissector_add

### DIFF
--- a/src/openflow-common.cpp
+++ b/src/openflow-common.cpp
@@ -56,8 +56,8 @@ proto_reg_handoff_openflow (void)
     {
     data_handle = find_dissector("data");
     openflow_handle = create_dissector_handle(dissect_openflow, proto_openflow);
-    dissector_add("tcp.port", OFP_TCP_PORT, openflow_handle);
-    dissector_add("tcp.port", 43984, openflow_handle);
+    dissector_add_uint("tcp.port", OFP_TCP_PORT, openflow_handle);
+    dissector_add_uint("tcp.port", 43984, openflow_handle);
     OFP_100_NS::Context->setHandles(data_handle, openflow_handle);
     OFP_110_NS::Context->setHandles(data_handle, openflow_handle);
     OFP_120_NS::Context->setHandles(data_handle, openflow_handle);


### PR DESCRIPTION
`dissector_add_uint` was introduced in Wireshark 1.6.0, with `dissector_add` remaining as a compatibility macro.  `dissector_add` was finally removed in 1.6.11.

That means that while this patch fixes compilation with 1.6.11 and newer, it breaks compatibility with versions earlier than 1.6.0. Would that be acceptable?

This closes CPqD/ofdissector#2.
